### PR TITLE
Fixes KeyError 'logs' and TypeError: argument of type 'NoneType' is not iterable

### DIFF
--- a/deebotozmo/__init__.py
+++ b/deebotozmo/__init__.py
@@ -295,14 +295,15 @@ class VacBot():
         self.fan_speed = speed
 
     def _handle_clean_logs(self, event):
-        response = event['logs']
+        response = event.get('logs')
         self.lastCleanLogs = []
 
         # Ecovacs API is changing their API, this request may not working properly
-        if response != None and len(response) >= 0:
+        if response is not None and len(response) >= 0:
             self.last_clean_image = response[0]['imageUrl']
             for cleanLog in response:
-                self.lastCleanLogs.append({'timestamp':cleanLog['ts'],'imageUrl': cleanLog['imageUrl'], 'type': cleanLog['type']})
+                self.lastCleanLogs.append({'timestamp': cleanLog['ts'], 'imageUrl': cleanLog['imageUrl'],
+                                           'type': cleanLog['type']})
 
     def _handle_water_info(self, event):
         response = event['body']['data']


### PR DESCRIPTION
This PR fixes two bugs:
- The event dict of the method __handle_clean_logs_ is not always containing the key 'logs' and therefore we get there a KeyError
- The parameter _message_ of the method __handle_clean_logs_ can be none. Add check for None and refactor the code there
Fixes https://github.com/And3rsL/Deebot-for-hassio/issues/41

I tested my changes successfully and now I have deployed this changes to my HA and until now I didn't see any errors