### PR TITLE
handle status code 502 different as the api is unreliable

### DIFF
--- a/deebotozmo/ecovacsiotmq.py
+++ b/deebotozmo/ecovacsiotmq.py
@@ -167,21 +167,23 @@ class EcoVacsIOTMQ(ClientMQTT):
         params = {}
         params.update(args)
 
-        es = datetime.datetime.now().timestamp()
-
-        _LOGGER.debug(str(es) + "| calling IOT api with {}".format(args))
+        _LOGGER.debug(f"Calling IOT api with {args}")
 
         headers = {'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android 5.1.1; A5010 Build/LMY48Z)',}
         url = (self.portal_url_format + "/iot/devmanager.do?mid=" + params['toType'] + "&did=" + params['toId'] + "&td=" + params['td'] + "&u=" + params['auth']['userid'] + "&cv=1.67.3&t=a&av=1.3.1").format(continent=self.continent)
         
         try:  
             with requests.post(url, headers=headers, json=params, timeout=20, verify=verify_ssl) as response:
-                if response.status_code != 200:
-                    _LOGGER.warning(str(es) + "| Error calling API " + str(url) + " StatusCode " + str(response.status_code))
+                if response.status_code == 502:
+                    _LOGGER.info("Error calling API (502): Unfortunately the ecovacs api is unreliable. Retrying in a few moments")
+                    _LOGGER.debug(f"URL was: {str(url)}")
+                    return {}
+                elif response.status_code != 200:
+                    _LOGGER.warning(f"Error calling API ({response.status_code}): {str(url)}")
                     return {}
 
                 data = response.json()
-                _LOGGER.debug(str(es) + "| got {}".format(data))
+                _LOGGER.debug(f"Got {data}")
 
                 return data
         except requests.exceptions.HTTPError as errh:


### PR DESCRIPTION
Handle status code 502 different as the api is unreliable.
- Change the level to info so it will not show in the log view.
- Add a debug log entry with the url so we get more information when debugging or some one is creating a issue.

Removed the datetime at the beginning of the log entries as the time is already saved.

Fixes https://github.com/And3rsL/Deebot-for-hassio/issues/58