### PR TITLE
added handling for scheduled cleaning in handle_clean_report and event handler subscriptions

### DIFF
--- a/deebotozmo/__init__.py
+++ b/deebotozmo/__init__.py
@@ -333,7 +333,7 @@ class VacBot():
     def _handle_clean_report(self, event):
         response = event['body']['data']
         if response['state'] == 'clean':
-            if response['trigger'] == 'app':
+            if response['trigger'] == 'app' or response['trigger'] == 'shed':
                 if response['cleanState']['motionState'] == 'working':
                     self.vacuum_status = 'STATE_CLEANING'
                 elif response['cleanState']['motionState'] == 'pause':


### PR DESCRIPTION
Hi,

I noticed, the status of my bot didn't change from 'STATE_DOCKED' when he was doing a scheduled run.
After invastigation I noticed the trigger is 'shed' in the event.
Also added simple EventHandler system to subscribe to events and use this to publishe data to e.g. own MQTT.

Thanks