### PR TITLE
Update ecovacsiotmq.py

### DIFF
--- a/deebotozmo/__init__.py
+++ b/deebotozmo/__init__.py
@@ -557,16 +557,16 @@ class VacBot():
             _LOGGER.warning("*** Error condition: " + err.condition)
 
     def request_all_statuses(self):
-        if not self.thread_statuses.isAlive():
+        if not self.thread_statuses.is_alive():
             self.thread_statuses = threading.Thread(target=self.refresh_statuses, daemon=False, name="schedule_thread_statuses")
             self.thread_statuses.start()
 
         if self.live_map_enabled:
-            if not self.thread_livemap.isAlive():
+            if not self.thread_livemap.is_alive():
                 self.thread_livemap = threading.Thread(target=self.refresh_liveMap, daemon=False, name="schedule_thread_livemap")
                 self.thread_livemap.start()
                 
-        if not self.thread_components.isAlive():
+        if not self.thread_components.is_alive():
             self.thread_components = threading.Thread(target=self.refresh_components, daemon=False, name="schedule_thread_components")
             self.thread_components.start()
     

--- a/deebotozmo/ecovacsiotmq.py
+++ b/deebotozmo/ecovacsiotmq.py
@@ -81,7 +81,7 @@ class EcoVacsIOTMQ(ClientMQTT):
 
     def schedule(self, timer_seconds, timer_function):
         self.scheduler.enter(timer_seconds, 1, self._run_scheduled_func,(timer_seconds, timer_function))
-        if not self.scheduler_thread.isAlive():
+        if not self.scheduler_thread.is_alive():
             self.scheduler_thread.start()
         
     def wait_until_ready(self):


### PR DESCRIPTION
fixed Thread.isAlive() -> Thread.is_alive() (see #19)

This seems to have been the correct method since at least Python 3.5