### PR TITLE
Add support for updating TrueDetect setting

### DIFF
--- a/deebotozmo/__init__.py
+++ b/deebotozmo/__init__.py
@@ -963,6 +963,11 @@ class VacBot:
         )
         self.refresh_statuses()
 
+    def SetTrueDetect(self, enable):
+        _LOGGER.debug("[Command] setTrueDetect enable=" + str(int(enable)))
+        self.exc_command('setTrueDetect', { 'enable': int(enable) })
+        self.refresh_statuses()
+
     def exc_command(self, action, params=None, **kwargs):
         self.send_command(VacBotCommand(action, params))
 

--- a/deebotozmo/cli.py
+++ b/deebotozmo/cli.py
@@ -116,7 +116,13 @@ def setfanspeed(speed):
 def setwaterLevel(level):
     dologin()
     vacbot.SetWaterLevel(level)
-    
+
+@cli.command(help='Set TrueDetect Obstacle Avoidance')
+@click.argument('enable', type=bool, required=True)
+def settruedetect(enable):
+    dologin()
+    vacbot.SetTrueDetect(enable);
+
 @cli.command(help='Returns to charger')
 def charge():
     dologin()


### PR DESCRIPTION
I've gone ahead and added the capability to enable/disable TrueDetect 3D Obstacle Avoidance through this library.

I've got a tricky area in my house which Deebot struggles to navigate because of reflective brushed alumninium kickboards, so only really does a good clean if object detection is disabled. My use case is that I want to use HA to do a normal clean of the house (with obstacle detection), then finish up with a kitchen clean with obstacle detection turned off 🤞

See also: https://github.com/And3rsL/Deebot-for-Home-Assistant/issues/121#issuecomment-864501670